### PR TITLE
Fix: Remove unused variable in test/site.test.js

### DIFF
--- a/test/site.test.js
+++ b/test/site.test.js
@@ -6,7 +6,7 @@ import { hasHostedByProfessionalWikiLogo } from '../src/site.js';
 
 describe('hasHostedByProfessionalWikiLogo', function () {
     // This function will be our mock for fetchc
-    const mockFetchcImplementation = async (url) => {
+    const mockFetchcImplementation = async () => {
         if (mockFetchcImplementation.shouldThrowError) {
             throw new Error(mockFetchcImplementation.errorMessage || 'Simulated fetch error');
         }


### PR DESCRIPTION
This commit removes the unused `url` parameter from the `mockFetchcImplementation` function in `test/site.test.js`, resolving an ESLint `no-unused-vars` error.