### PR TITLE
Add Month of last edit (P73) tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -358,7 +358,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -854,7 +853,6 @@
       "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/src/events/bus.js
+++ b/src/events/bus.js
@@ -54,6 +54,7 @@ export const Events = {
     DATA_REVERSE_DNS: 'wiki.data.reverse-dns',
     DATA_PAGE_META: 'wiki.data.page-meta',
     DATA_WB_METADATA: 'wiki.data.wb-metadata',
+    DATA_LAST_EDIT: 'wiki.data.last-edit',
     
     // Edit events
     EDIT_CLAIM_ENSURE: 'edit.claim.ensure',

--- a/src/jobs/fetchers/index.js
+++ b/src/jobs/fetchers/index.js
@@ -8,6 +8,7 @@ import manifestFetcher from './manifest.js';
 import reverseDnsFetcher from './reverse-dns.js';
 import entityCountsFetcher from './entity-counts.js';
 import externalLinksFetcher from './external-links.js';
+import lastEditFetcher from './last-edit.js';
 
 export const fetchers = [
     siteinfoFetcher,
@@ -16,6 +17,7 @@ export const fetchers = [
     reverseDnsFetcher,
     entityCountsFetcher,
     externalLinksFetcher,
+    lastEditFetcher,
 ];
 
 /**

--- a/src/jobs/fetchers/last-edit.js
+++ b/src/jobs/fetchers/last-edit.js
@@ -1,0 +1,63 @@
+/**
+ * Last Edit Fetcher - Fetches the wiki's last edit timestamp from recent changes or logs
+ *
+ * Subscribes to: wiki.context-ready
+ * Emits: wiki.data.last-edit
+ */
+
+import { eventBus, Events } from '../../events/bus.js';
+import { fetchc } from '../../fetch.js';
+import { HEADERS } from '../../general.js';
+
+/**
+ * Fetch last edit timestamp from a wiki's action API
+ * @param {string} actionApi - The action API URL
+ * @returns {Promise<{timestamp: string, apiUrl: string}|null>}
+ */
+export async function fetchLastEdit(actionApi) {
+    try {
+        const apiUrl = actionApi + '?action=query&list=recentchanges|logevents&rclimit=1&lelimit=1&format=json';
+        const response = await fetchc(apiUrl, { headers: HEADERS });
+        if (!response) return null;
+
+        const data = await response.json();
+        if (!data || !data.query) return null;
+
+        const rcTimestamp = data.query.recentchanges?.[0]?.timestamp;
+        const logTimestamp = data.query.logevents?.[0]?.timestamp;
+
+        if (!rcTimestamp && !logTimestamp) return null;
+
+        // Take the latest of the two
+        let timestamp;
+        if (rcTimestamp && logTimestamp) {
+            timestamp = rcTimestamp > logTimestamp ? rcTimestamp : logTimestamp;
+        } else {
+            timestamp = rcTimestamp || logTimestamp;
+        }
+
+        return { timestamp, apiUrl };
+    } catch (error) {
+        console.log(`❌ Failed to fetch last edit: ${error.message}`);
+        return null;
+    }
+}
+
+/**
+ * Register the last edit fetcher with the event bus
+ * @param {Object} queues - Queue instances { many, four, one }
+ */
+export function register(queues) {
+    eventBus.register(Events.WIKI_CONTEXT_READY, 'fetcher:last-edit', ({ wiki }) => {
+        if (!wiki.actionApi) return;
+
+        queues.many.add(async () => {
+            const lastEdit = await fetchLastEdit(wiki.actionApi);
+            if (lastEdit) {
+                eventBus.emit(Events.DATA_LAST_EDIT, { wiki, lastEdit, queues });
+            }
+        }, { jobName: `fetch:last-edit:${wiki.item}` });
+    });
+}
+
+export default { register, fetchLastEdit };

--- a/src/jobs/processors/wiki/index.js
+++ b/src/jobs/processors/wiki/index.js
@@ -7,6 +7,7 @@ import activityStatusProcessor from './activity-status.js';
 import labelsDescriptionsProcessor from './labels-descriptions.js';
 import urlNormalizerProcessor from './url-normalizer.js';
 import wikiLinksProcessor from './wiki-links.js';
+import lastEditProcessor from './last-edit.js';
 
 export const processors = [
     mediawikiVersionProcessor,
@@ -14,6 +15,7 @@ export const processors = [
     labelsDescriptionsProcessor,
     urlNormalizerProcessor,
     wikiLinksProcessor,
+    lastEditProcessor,
 ];
 
 /**

--- a/src/jobs/processors/wiki/last-edit.js
+++ b/src/jobs/processors/wiki/last-edit.js
@@ -1,0 +1,87 @@
+/**
+ * Last Edit Processor - Updates the month of last edit (P73)
+ *
+ * Subscribes to: wiki.data.last-edit
+ * Property: P73 (month of last edit)
+ */
+
+import { eventBus, Events } from '../../../events/bus.js';
+import { world } from '../../../world.js';
+
+const PROPERTY = 'P73';
+const PROPERTY_NAME = 'month of last edit';
+
+/**
+ * Process last edit timestamp
+ * @param {Object} context - { wiki, lastEdit, queues }
+ */
+export function process({ wiki, lastEdit, queues }) {
+    if (!lastEdit?.timestamp || !lastEdit?.apiUrl) return;
+
+    const { timestamp, apiUrl } = lastEdit;
+
+    // Extract year and month, e.g., 2024-03-21T12:34:56Z -> 2024-03
+    const dateParts = timestamp.split('T')[0].split('-');
+    const year = dateParts[0];
+    const month = dateParts[1];
+    const yearMonth = `${year}-${month}`;
+    const yearMonthDay = `${yearMonth}-01`; // Wikibase time needs a day
+
+    const today = new Date().toISOString().split('T')[0];
+
+    // precision 10 is month
+    const desiredValue = {
+        time: `+${yearMonthDay}T00:00:00Z`,
+        timezone: 0,
+        before: 0,
+        after: 0,
+        precision: 10,
+        calendarmodel: 'http://www.wikidata.org/entity/Q1985727'
+    };
+
+    // If no P73 claim, add one with references
+    if (!wiki.simpleClaims[PROPERTY]) {
+        world.queueWork.claimEnsure(
+            queues.one,
+            {
+                id: wiki.item,
+                property: PROPERTY,
+                value: desiredValue,
+                references: { P21: apiUrl, P22: today }
+            },
+            { summary: `Add [[Property:${PROPERTY}]] claim for ${yearMonth} based on the latest edit or log entry of the wiki` }
+        );
+        return;
+    }
+
+    // If there's a P73 claim, check if it needs update
+    if (wiki.simpleClaims[PROPERTY].length === 1) {
+        const existingFullValue = wiki.entity.claims[PROPERTY][0].mainsnak.datavalue.value;
+        const existingTime = existingFullValue.time; // e.g. +2024-03-01T00:00:00Z
+        const existingPrecision = existingFullValue.precision;
+
+        const existingYearMonth = existingTime.substring(1, 8); // 2024-03
+
+        if (existingYearMonth !== yearMonth || existingPrecision !== 10) {
+             world.queueWork.claimEnsure(
+                queues.one,
+                {
+                    id: wiki.item,
+                    property: PROPERTY,
+                    value: desiredValue,
+                    references: { P21: apiUrl, P22: today }
+                },
+                { summary: `Update [[Property:${PROPERTY}]] claim to ${yearMonth} based on the latest edit or log entry of the wiki` }
+            );
+        }
+    }
+}
+
+/**
+ * Register the processor with the event bus
+ */
+export function register() {
+    eventBus.register(Events.DATA_LAST_EDIT, 'processor:last-edit', process);
+}
+
+export default { register, process, PROPERTY, PROPERTY_NAME };

--- a/src/world.js
+++ b/src/world.js
@@ -312,6 +312,12 @@ world.queueWork.claimEnsure = async (queue, data, requestConfig) => {
                         : parseInt(String(desired), 10)
                     return a === b
                 }
+                if (typeof c.value === 'object' && c.value !== null && 'time' in c.value) {
+                    // time object - compare time and precision
+                    const isTimeMatch = c.value.time === desired.time;
+                    const isPrecisionMatch = c.value.precision === desired.precision;
+                    return isTimeMatch && isPrecisionMatch;
+                }
                 return c.value === desired
             } catch {
                 return false


### PR DESCRIPTION
This PR adds functionality to automatically track the month of the last edit for wikis on wikibase.world.

Changes:
1.  **Event Bus**: Added `DATA_LAST_EDIT` to `Events`.
2.  **Fetcher**: Created `src/jobs/fetchers/last-edit.js` to fetch the latest timestamp from both `recentchanges` and `logevents`.
3.  **Processor**: Created `src/jobs/processors/wiki/last-edit.js` to process the timestamp and ensure `P73` (Month of last edit) is set with month precision (10).
4.  **World Helper**: Updated `src/world.js`'s `claimEnsure` to correctly compare Wikibase time objects, preventing unnecessary duplicate edits.
5.  **Registration**: Integrated the new fetcher and processor into the existing pipeline.

Verification:
- Manual validation script confirmed the fetcher correctly retrieves data from MediaWiki APIs.
- Logic verified for both new claims and updates to existing claims (including precision changes).
- Code review performed and feedback addressed.

---
*PR created automatically by Jules for task [3790079923950897720](https://jules.google.com/task/3790079923950897720) started by @addshore*