### PR TITLE
Use HEAD requests for EditURI discovery

### DIFF
--- a/cmd/tidy-world.js
+++ b/cmd/tidy-world.js
@@ -60,8 +60,21 @@ function setupEventFlow() {
     eventBus.register(Events.WIKI_DISCOVERED, 'core:check-alive', (wiki) => {
         queues.many.add(async () => {
             try {
-                const response = await fetchc(wiki.site, { headers: HEADERS });
-                const responseText = await response?.text();
+                let response = await fetchc(wiki.site, { method: 'HEAD', headers: HEADERS });
+                let responseText;
+
+                if (response && response.status === 200) {
+                    const linkHeader = response.headers.get('Link');
+                    if (linkHeader && linkHeader.includes('rel="EditURI"')) {
+                        // If we have the EditURI in the Link header, we consider it alive
+                        eventBus.emit(Events.WIKI_ALIVE, { wiki, response });
+                        return;
+                    }
+                }
+
+                // Fallback to GET if HEAD failed or didn't have EditURI Link header
+                response = await fetchc(wiki.site, { headers: HEADERS });
+                responseText = await response?.text();
                 
                 if (!response || !responseText) {
                     eventBus.emit(Events.WIKI_DEAD, { wiki, reason: 'No response' });
@@ -131,14 +144,14 @@ function setupEventFlow() {
  */
 async function buildWikiContext(wiki, response) {
     wiki.url = wiki.site;
-    wiki.responseText = response.loadedText;
+    wiki.responseText = response.loadedText || '';
     wiki.domain = wiki.site.replace('https://', '').replace('http://', '').split('/')[0];
     
     // Perform reverse DNS lookup
     wiki.reverseDNS = await fetchReverseDNS(wiki.domain);
     
     // Extract action API from EditURI
-    wiki.actionApi = extractActionApi(wiki.responseText);
+    wiki.actionApi = extractActionApi(wiki.responseText, response);
     wiki.restApi = wiki.actionApi?.replace('/api.php', '/rest.php') || null;
     
     // Extract page meta data
@@ -158,13 +171,33 @@ async function buildWikiContext(wiki, response) {
 }
 
 /**
- * Extract action API URL from response text
+ * Extract action API URL from response text or Link header
  */
-function extractActionApi(responseText) {
-    const matches = responseText.match(/<link rel="EditURI" type="application\/rsd\+xml" href="(.+?)"/);
-    if (!matches) return null;
-    
-    let apiUrl = matches[1].replace('?action=rsd', '');
+function extractActionApi(responseText, response = null) {
+    let apiUrl = null;
+
+    // Try Link header first
+    if (response && typeof response.headers?.get === 'function') {
+        const linkHeader = response.headers.get('Link');
+        if (linkHeader) {
+            const match = linkHeader.match(/<(.+?)>;\s*rel="EditURI"/);
+            if (match) {
+                apiUrl = match[1];
+            }
+        }
+    }
+
+    // Fallback to HTML parsing
+    if (!apiUrl && responseText) {
+        const matches = responseText.match(/<link rel="EditURI" type="application\/rsd\+xml" href="(.+?)"/);
+        if (matches) {
+            apiUrl = matches[1];
+        }
+    }
+
+    if (!apiUrl) return null;
+
+    apiUrl = apiUrl.replace('?action=rsd', '');
     if (apiUrl.startsWith('//')) {
         apiUrl = 'https:' + apiUrl;
     }

--- a/src/site.js
+++ b/src/site.js
@@ -3,15 +3,29 @@ import { HEADERS } from './../src/general.js';
 
 const checkOnlineAndWikibase = async (url) => {
     try{
-        const response = await fetchc(url, { headers: HEADERS })
-        const responseText = await response.text();
-        response.loadedText = responseText
-        if (!(response.status == 200 || ( response.status === 404 && responseText.includes("There is currently no text in this page") ) ) ) {
-            return {result: false, text: `❌ The URL ${url} is not currently a 200 or a 404 with the expected MediaWiki text`}
+        let response = await fetchc(url, { method: 'HEAD', headers: HEADERS })
+        let responseText;
+        let actionApiMatchs;
+
+        if (response && response.status === 200) {
+            const linkHeader = response.headers.get('Link');
+            if (linkHeader) {
+                actionApiMatchs = linkHeader.match(/<(.+?)>;\s*rel="EditURI"/);
+            }
         }
 
-        // Bail if it doesnt have a correct EditURI
-        let actionApiMatchs = responseText.match(/<link rel="EditURI" type="application\/rsd\+xml" href="(.+?)"/)
+        if (!actionApiMatchs) {
+            response = await fetchc(url, { headers: HEADERS })
+            responseText = await response.text();
+            response.loadedText = responseText
+            if (!(response.status == 200 || ( response.status === 404 && responseText.includes("There is currently no text in this page") ) ) ) {
+                return {result: false, text: `❌ The URL ${url} is not currently a 200 or a 404 with the expected MediaWiki text`}
+            }
+
+            // Bail if it doesnt have a correct EditURI
+            actionApiMatchs = responseText.match(/<link rel="EditURI" type="application\/rsd\+xml" href="(.+?)"/)
+        }
+
         if (!actionApiMatchs) {
             return {result: false, text: `❌ The URL ${url} does not have a correct EditURI for MediaWiki`}
         }

--- a/test/site.test.js
+++ b/test/site.test.js
@@ -2,7 +2,77 @@
 /* global describe, it, beforeEach */
 import { expect } from 'chai';
 import { setMockFetchc } from '../src/fetch.js';
-import { hasHostedByProfessionalWikiLogo } from '../src/site.js';
+import { hasHostedByProfessionalWikiLogo, checkOnlineAndWikibase } from '../src/site.js';
+
+describe('checkOnlineAndWikibase', function () {
+    const mockFetchcImplementation = async (url, options) => {
+        if (mockFetchcImplementation.shouldThrowError) {
+            throw new Error(mockFetchcImplementation.errorMessage || 'Simulated fetch error');
+        }
+
+        if (options && options.method === 'HEAD') {
+            return {
+                status: mockFetchcImplementation.headStatus || 200,
+                headers: {
+                    get: (name) => {
+                        if (name.toLowerCase() === 'link') {
+                            return mockFetchcImplementation.linkHeader || null;
+                        }
+                        return null;
+                    }
+                }
+            };
+        }
+
+        if (url.includes('Special:Version')) {
+            return {
+                status: 200,
+                text: async () => 'mw-version-ext-wikibase-WikibaseRepository'
+            }
+        }
+
+        return {
+            status: mockFetchcImplementation.status || 200,
+            text: async () => mockFetchcImplementation.htmlContent,
+            headers: {
+                get: () => null
+            }
+        };
+    };
+
+    beforeEach(() => {
+        mockFetchcImplementation.htmlContent = '';
+        mockFetchcImplementation.shouldThrowError = false;
+        mockFetchcImplementation.errorMessage = '';
+        mockFetchcImplementation.headStatus = 200;
+        mockFetchcImplementation.status = 200;
+        mockFetchcImplementation.linkHeader = null;
+        setMockFetchc(mockFetchcImplementation);
+    });
+
+    it('successfully validates via HEAD request with Link header', async function () {
+        mockFetchcImplementation.linkHeader = '<https://example.com/w/api.php>; rel="EditURI"';
+        const result = await checkOnlineAndWikibase('https://example.com');
+        expect(result.result).to.not.be.false;
+        expect(result.text).to.equal('https://example.com');
+    });
+
+    it('falls back to GET if HEAD has no Link header', async function () {
+        mockFetchcImplementation.linkHeader = null;
+        mockFetchcImplementation.htmlContent = '<html><head><link rel="EditURI" type="application/rsd+xml" href="https://example.com/w/api.php?action=rsd" /></head><body>MediaWiki</body></html>';
+        const result = await checkOnlineAndWikibase('https://example.com');
+        expect(result.result).to.not.be.false;
+        expect(result.text).to.equal('https://example.com');
+    });
+
+    it('fails if neither HEAD nor GET provide EditURI', async function () {
+        mockFetchcImplementation.linkHeader = null;
+        mockFetchcImplementation.htmlContent = '<html><body>Not a wiki</body></html>';
+        const result = await checkOnlineAndWikibase('https://example.com');
+        expect(result.result).to.be.false;
+        expect(result.text).to.contain('does not have a correct EditURI');
+    });
+});
 
 describe('hasHostedByProfessionalWikiLogo', function () {
     // This function will be our mock for fetchc


### PR DESCRIPTION
Implement optimization to use HEAD requests for MediaWiki validation and EditURI discovery via the Link header, with a fallback to GET requests for compatibility.

---
*PR created automatically by Jules for task [18046918630075971097](https://jules.google.com/task/18046918630075971097) started by @addshore*